### PR TITLE
Update tagsinput.js

### DIFF
--- a/tagsinput.js
+++ b/tagsinput.js
@@ -204,7 +204,7 @@ class Tagify {
             atStart = this.caretAtStart(e);
 
           if (activeTag) {
-            selectedTag = this.container.querySelector('[data-tag="' + activeTag.innerText + '"]');
+            selectedTag = this.container.querySelector('[data-tag="' + activeTag.innerText.trim() + '"]');
           }
 
           if (selectedTag) {


### PR DESCRIPTION
Added a trim operator on line 205 to catch a linebreak that broke the delete functionality. (At least in my Chrome for Mac Version 63.0.3239.84 (Official Build) (64-bit).)