### PR TITLE
Allow show/hide delete button using DOM attribute

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -49,6 +49,8 @@ export default class Tagify {
       duplicates: true
     }
     this.element = element;
+    if( element.getAttribute("data-allow-delete") )
+      defaultOptions.allowDelete = element.getAttribute("data-allow-delete") == 'true';
     this.options = Object.assign({}, defaultOptions, options);
 
     this.init();


### PR DESCRIPTION
Someone wants to hide delete buttons in some cases.
To do this easily, we need a special attribute 'allowDelete'
in `input` tag.

You can use this like below:
`<input type='tags' allowDelete='true' value='tag1,tag2'>`